### PR TITLE
Made changes to ensure "npm test" passes on ppc64le arch

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = { canWatchdog: canWatchdog };
+
+function canWatchdog() {
+  return process.platform === 'linux' &&
+         (process.arch === 'ia32' || process.arch === 'x64') &&
+         (process.versions.v8 < '3.15' || process.versions.v8 >= '3.29');
+}

--- a/test/test-event-loop-watchdog.js
+++ b/test/test-event-loop-watchdog.js
@@ -1,12 +1,15 @@
 'use strict';
 
-if (process.platform !== 'linux') {
+/*if (process.platform !== 'linux') {
   console.log('1..0 # SKIP watchdog is Linux-only for now');
   return;
-}
+}*/
+var common = require('./common');
 
-if (process.versions.v8 >= '3.15' && process.versions.v8 < '3.29') {
-  console.log('1..0 # SKIP watchdog is incompatible with this node version');
+//if (process.versions.v8 >= '3.15' && process.versions.v8 < '3.29') {
+//  console.log('1..0 # SKIP watchdog is incompatible with this node version');
+if (!common.canWatchdog()) {
+  console.log('1..0 # SKIP no watchdog for this arch/platform/runtime');
   return;
 }
 

--- a/test/test-no-watchdog.js
+++ b/test/test-no-watchdog.js
@@ -3,9 +3,11 @@
 var addon = require('../lib/addon');
 var agent = require('../');
 var assert = require('assert');
+var common = require('./common');
 var profiler = require('../lib/profilers/cpu');
 
-if (process.platform === 'linux') {
+//if (process.platform === 'linux') {
+if (common.canWatchdog()) {
   addon.startCpuProfiling = function(timeout) { if (timeout) return 'BAM'; };
 }
 

--- a/test/test-watchdog-activation-count.js
+++ b/test/test-watchdog-activation-count.js
@@ -1,12 +1,15 @@
 'use strict';
 
-if (process.platform !== 'linux') {
+/*if (process.platform !== 'linux') {
   console.log('1..0 # SKIP watchdog is Linux-only for now');
   return;
-}
+}*/
+var common = require('./common');
 
-if (process.versions.v8 >= '3.15' && process.versions.v8 < '3.29') {
-  console.log('1..0 # SKIP watchdog is incompatible with this node version');
+//if (process.versions.v8 >= '3.15' && process.versions.v8 < '3.29') {
+//  console.log('1..0 # SKIP watchdog is incompatible with this node version');
+if (!common.canWatchdog()) {
+  console.log('1..0 # SKIP no watchdog for this arch/platform/runtime');
   return;
 }
 


### PR DESCRIPTION
While performing "npm test" on a "ppc" architecture, test case pertaining to "watchdog profiling" were failing. The failure was due to the fact that watchdog profiling  was not supported on ppc64le arch .
Made changes to ensure that those test cases are tested only on x64/32 arch type.